### PR TITLE
fix: Image data comparison hasn't worked. Now I check if there are any strokes

### DIFF
--- a/files/client/modules/esignature/src/views/fields/esignature.js
+++ b/files/client/modules/esignature/src/views/fields/esignature.js
@@ -187,15 +187,13 @@ Espo.define('esignature:views/fields/esignature', 'views/fields/base', function 
         },
         
         inlineEditSave: function () { // substitutes same function at base.js   
-            // convert the canvas drawing to image code 
-            var imageCode = this.$el.jSignature('getData'); 
-            // compare the contents of the current vs blank canvass to make sure there's a signature to be saved
-            console.log(imageCode)
-            if(this.blankCanvassCode[1] === imageCode) {
-                alert("No signature was entered");
-                this.inlineEditClose();
+            // compare the amount of strokes to make sure there's a signature to be saved
+            const strokes = this.$el.jSignature('getData', 'native');
+            if (!strokes.length) {
+                alert(this.translate('noSignatureEntered', 'messages', 'Global'));
                 return;
-            }  
+            }
+
             // register the signature time stamp
             var d = new Date();
             var timestamp = eSignatureISODateString(d);             


### PR DESCRIPTION
🧾 Summary

This fixes the validation logic for empty signatures.
Previously we compared image data (PNG data URL) against a stored “blank” reference, which proved unreliable.
We now validate by checking whether the jSignature pad contains any strokes.

✅ Changes

Replaced PNG/DataURL equality check with jSignature('getData', 'native') length check.

Treat signature as empty when no stroke segments are present.

Kept image export for storage/display (getData('image')) unchanged.

🧪 Testing

Open a record with the eSignature field and click to sign.

Without drawing, try to save → expect validation message (no save).

Draw a small stroke and save → expect successful save and timestamp.

(Optional) Press Undo/Reset and try again → should be treated as empty.

⚙️ Technical Notes

native returns an array of stroke segments; [].length === 0 → empty.

This avoids false positives that occurred when comparing PNG data URLs of “blank” canvases.

📈 Impact

More robust empty-signature detection.

No changes to backend or database schema.
