### PR TITLE
fix: Replace <a> element with <button> to comply with Content Security Policy

### DIFF
--- a/files/client/modules/esignature/src/views/fields/esignature.js
+++ b/files/client/modules/esignature/src/views/fields/esignature.js
@@ -131,7 +131,11 @@ Espo.define('esignature:views/fields/esignature', 'views/fields/base', function 
 
         initInlineEsignatureEdit: function () { // custom function equivalent to "initInlineEdit" at base.js   
             var $cell = this.getCellElement();
-            var $editLink = $('<a href="javascript:" class="pull-right inline-edit-link hidden"><span class="fas fa-pencil-alt fa-sm"></span></a>');
+            var $editLink = $(
+                '<button type="button" class="pull-right inline-edit-link hidden" aria-label="Edit" style="background-color:unset;border:unset;">' +
+                    '<span class="fas fa-pencil-alt fa-sm"></span>' +
+                '</button>'
+                );
             if ($cell.length === 0 || typeof(this.model.get(this.name))=== 'undefined') {
                 this.listenToOnce(this, 'after:render', this.initInlineEsignatureEdit, this);
                 return;
@@ -143,7 +147,9 @@ Espo.define('esignature:views/fields/esignature', 'views/fields/base', function 
             }
             // after the element has been rendered, add the hidden pencil icon link
             $cell.prepend($editLink);
-            $editLink.on('click', function () {
+            $editLink.on('click', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
                 // when clicked, call the custom signature field inline edit function
                 this.inlineEsignatureEdit(); 
             // bind the functionality to the pencil icon link    


### PR DESCRIPTION
📝 Description

This change replaces the inline element used as an edit trigger (the pencil icon) with a proper element.

Previously, using caused a Content Security Policy (CSP) violation in EspoCRM because inline JavaScript execution (javascript: URLs) is disallowed under strict CSP headers.

✅ Changes

Replaced with a semantic
element.

Preserved existing CSS classes and event handlers to maintain the same look and behavior.

Ensured accessibility and compliance with modern security best practices.

🎯 Result

No more CSP warnings or console errors when clicking the edit (pencil) icon.

Improved security and browser compatibility.

Functionality remains identical for users — only the underlying element type changed.

🧩 Technical Notes

This fix is frontend-only; no backend logic was affected.